### PR TITLE
Multi-Site Support

### DIFF
--- a/src/templates/_fields/colorit/settings.twig
+++ b/src/templates/_fields/colorit/settings.twig
@@ -123,3 +123,14 @@
     }) }}
 
 </div>
+
+{% if not field.presetMode and craft.app.sites.getTotalSites() > 1 %}
+    {{ forms.lightswitchField({
+        label: "Multi-Site Support"|t('colorit'),
+        instructions: "Keep this field's settings specific to each site."|t('colorit'),
+        id: 'multiSiteSupport',
+        name: 'multiSiteSupport',
+        on: field.multiSiteSupport,
+        errors: field.getErrors('multiSiteSupport')
+    }) }}
+{% endif %}


### PR DESCRIPTION
### Use Case
I wanted to be able to set field specific settings per site. I.e., it'd be great to create a bunch of presets (e.g. themes for each site), and toggle that preset on the _same field_.

### What I did
Craft doesn't support multi-site field settings out of the box. The simplest approach I could think of was to simply store the site specific settings in an array key called "siteSettings", and direct Craft to load those ones when required, otherwise falling back to the default settings.

I added a toggle so users can choose whether their color settings will be propagated across all sites, or specific to each site.

I also removed the translation field, as I don't think it's relevant for this field type? (Correct me if I'm wrong!).

### How to test
1. Install plugin
2. Create some presets
3. Create multiple sites
4. Create a `colorit` field and assign to a section
5. Test setting a preset on the field, and ensure it's the same between each site.
6. Now toggle the "Multi-Site" light switch, and ensure you can set individual presets for each site.
7. Do the same with color palettes.
8. Ensure the correct colors display on you entries.

(Note: I tested mine inside a matrix).